### PR TITLE
Update version check and make release workflows

### DIFF
--- a/.github/deploy/version_check.sh
+++ b/.github/deploy/version_check.sh
@@ -5,8 +5,10 @@ set -e
 #
 # Reads version from Cargo.toml and checks it against tags
 #
-# Credit to @richfitz for this from the dust package:
+# Modified from
 # https://github.com/mrc-ide/dust/blob/master/scripts/version_check
+# by  @richfitz for the dust package.
+#
 VERSION=${1:-$(grep '^version' Cargo.toml  | sed 's/.*= *//' | sed 's/"//g')}
 TAG="v${VERSION}"
 
@@ -27,34 +29,11 @@ git fetch --quiet
 BRANCH_DEFAULT=$(git remote show origin | awk '/HEAD branch/ {print $NF}')
 LAST_TAG=$(git describe --tags --abbrev=0 "origin/${BRANCH_DEFAULT}")
 
-echo "Last tag was $LAST_TAG"
+echo "Pushed tag is $LAST_TAG"
 
 if git rev-parse "$TAG" >/dev/null 2>&1; then
-    echo "[ERROR] Tag $TAG already exists - update version number in Cargo.toml"
-    exit 1
+    echo "[OK] Version number $VERSION in Cargo.toml matches tag $TAG"
 else
-    echo "[OK] Version number not yet present as git tag"
-fi
-
-MAJOR=$(echo $VERSION | cut -d. -f1)
-MINOR=$(echo $VERSION | cut -d. -f2)
-PATCH=$(echo $VERSION | cut -d. -f3)
-
-LAST_VERSION=$(echo "$LAST_TAG" | sed 's/^v//')
-LAST_MAJOR=$(echo $LAST_VERSION | cut -d. -f1)
-LAST_MINOR=$(echo $LAST_VERSION | cut -d. -f2)
-LAST_PATCH=$(echo $LAST_VERSION | cut -d. -f3)
-
-if (( $MAJOR > $LAST_MAJOR )); then
-    echo "[OK] Increasing MAJOR version"
-    exit $EXIT_CODE
-elif (( $MINOR > $LAST_MINOR )); then
-    echo "[OK] Increasing MINOR version"
-    exit $EXIT_CODE
-elif (( $PATCH > $LAST_PATCH )); then
-    echo "[OK] Increasing PATCH version"
-    exit $EXIT_CODE
-else
-    echo "[ERROR] Version number has not increased relative to $LAST_VERSION"
+    echo "[ERROR] Tag $TAG does not match version $VERSION in Cargo.toml - update version number in Cargo.toml"
     exit 1
 fi

--- a/.github/workflows/check_version.yml
+++ b/.github/workflows/check_version.yml
@@ -1,13 +1,15 @@
+name: Version check
+
 on:
-  pull_request:
+  push:
+    tags:
+      - "v*.*.*"
     branches:
       - main
 
-name: Check version
-
 jobs:
   version-check:
-    name: Check pull request before merging
+    name: Check tags
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -1,9 +1,11 @@
 name: Make new release
 
 on:
-  push:
-    tags:
-      - "v*.*.*"
+  workflow_run:
+    workflows: ['Version check']
+    types: [completed]
+    branches:
+      - 'main'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
- Run version check only when a new tag is pushed to main
- Check the pushed tag against Cargo.toml, error if they don't match
- Trigger make release only if version check is OK